### PR TITLE
Update MembersAPI.json to use stringArrayColumnName

### DIFF
--- a/MembersAPI.json
+++ b/MembersAPI.json
@@ -99,7 +99,7 @@
                             "path": "/api/Educators"
                         },
                         "processing_options": {
-                            "stringColumnName": "Username"
+                            "stringArrayColumnName": "Username"
                          },
                         "semantics": "create",
                         "resource_allowance_default": "optional",
@@ -910,7 +910,7 @@
                             "path": "/api/Students"
                         },
                         "processing_options": {
-                            "stringColumnName": "Username"
+                            "stringArrayColumnName": "Username"
                          },
                         "semantics": "create",
                         "resource_allowance_default": "optional",


### PR DESCRIPTION
I see we somewhere changed the code to always use stringArrayColumnName instead of stringColumnName for one and stringArrayColumnName for other calls. I think that is fine, so just change the json should fix it.